### PR TITLE
Represent the QIIME2 version as a string

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -27,7 +27,7 @@ group_name: ssh-workshops
 vpc_cidr_block: 172.23.0.0/16
 workshop_key_fn: workshopkey-private.pem
 
-qiime2_release: 2017.7
+qiime2_release: "2017.10"
 miniconda_path: /mnt/home/miniconda3
 
 security_groups:


### PR DESCRIPTION
This change is necessary to avoid inadvertent interpretation of the
version as a float.