### PR TITLE
update py version in environment file url

### DIFF
--- a/roles/qiime2/tasks/main.yml
+++ b/roles/qiime2/tasks/main.yml
@@ -44,7 +44,7 @@
 - name: download env file
   become: true
   get_url:
-    url: https://data.qiime2.org/distro/core/qiime2-{{ qiime2_release }}-py36-linux-conda.yml
+    url: https://data.qiime2.org/distro/core/qiime2-{{ qiime2_release }}-py38-linux-conda.yml
     dest: /tmp/env.yml
   when: not env.stat.exists
 


### PR DESCRIPTION
I discovered this outdated URL when provisioning a cluster for the November, 2021 CSU workshop. 
